### PR TITLE
Mode S surveillance identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 nom = "5"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 assert_approx_eq = "1.1"

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -35,7 +35,7 @@ impl fmt::Display for CrcError {
 
 impl Error for CrcError {}
 
-pub fn mode_s_crc(input: &[u8], num_bytes: u8) -> Result<u32, CrcError> {
+pub(crate) fn mode_s_crc(input: &[u8], num_bytes: u8) -> Result<u32, CrcError> {
     let mut rem = 0u32;
     if num_bytes < 3 {
         return Err(CrcError(String::from(

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,0 +1,56 @@
+use core::fmt;
+use std::error::Error;
+
+// CRC table generation and Mode S checksumming ported from
+// https://github.com/wiedehopf/readsb/blob/177545fbff8cc2be9d7e9b9b109c5c1046c2642b/crc.c
+
+const MODES_GENERATOR_POLY: u32 = 0xfff409;
+
+lazy_static! {
+    static ref CRC_TABLE: [u32; 256] = {
+        let mut result = [0u32; 256];
+        for i in 0..256 {
+            let mut c = i << 16;
+            for _j in 0..8 {
+                if c & 0x800000 != 0 {
+                    c = (c << 1) ^ MODES_GENERATOR_POLY;
+                } else {
+                    c <<= 1;
+                }
+            }
+            result[i as usize] = c & 0x00ffffff;
+        }
+        result
+    };
+}
+
+#[derive(Debug, Clone)]
+pub struct CrcError(String);
+
+impl fmt::Display for CrcError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for CrcError {}
+
+pub fn mode_s_crc(input: &[u8], num_bytes: u8) -> Result<u32, CrcError> {
+    let mut rem = 0u32;
+    if num_bytes < 3 {
+        return Err(CrcError(String::from(
+            "num_bytes must be >= 3 to calculate Mode S CRC",
+        )));
+    }
+    let num_bytes = num_bytes as usize;
+    for byte in input.iter().take(num_bytes - 3) {
+        let idx = (*byte as u32) ^ ((rem & 0xff0000) >> 16);
+        rem = (rem << 8) ^ CRC_TABLE[idx as usize];
+        rem &= 0xffffff;
+    }
+    rem = rem
+        ^ ((input[num_bytes - 3] as u32) << 16)
+        ^ ((input[num_bytes - 2] as u32) << 8)
+        ^ (input[num_bytes - 1] as u32);
+    Ok(rem)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,13 @@
 //!   - **TC 19**: Airborne velocity
 
 pub mod cpr;
+mod crc;
 mod parser;
 mod types;
 
+pub use crc::*;
 pub use parser::*;
 pub use types::*;
+
+#[macro_use]
+extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ mod crc;
 mod parser;
 mod types;
 
-pub use crc::*;
 pub use parser::*;
 pub use types::*;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,4 @@
+use super::crc::*;
 use super::types::*;
 use nom::bits::bits;
 use nom::branch::alt;
@@ -198,10 +199,94 @@ fn parse_unknown(input: (&[u8], usize)) -> IResult<(&[u8], usize), MessageKind> 
     Ok((input, MessageKind::Unknown))
 }
 
+pub fn decode_id_13_field(f: u16) -> u16 {
+    let mut hex_gillham = 0;
+    if f & 0x1000 != 0 {
+        hex_gillham |= 0x0010;
+    } // Bit 12 = C1
+    if f & 0x0800 != 0 {
+        hex_gillham |= 0x1000;
+    } // Bit 11 = A1
+    if f & 0x0400 != 0 {
+        hex_gillham |= 0x0020;
+    } // Bit 10 = C2
+    if f & 0x0200 != 0 {
+        hex_gillham |= 0x2000;
+    } // Bit  9 = A2
+    if f & 0x0100 != 0 {
+        hex_gillham |= 0x0040;
+    } // Bit  8 = C4
+    if f & 0x0080 != 0 {
+        hex_gillham |= 0x4000;
+    } // Bit  7 = A4
+      //if (ID13Field & 0x0040) {hexGillham |= 0x0800;} // Bit  6 = X  or M
+    if f & 0x0020 != 0 {
+        hex_gillham |= 0x0100;
+    } // Bit  5 = B1
+    if f & 0x0010 != 0 {
+        hex_gillham |= 0x0001;
+    } // Bit  4 = D1 or Q
+    if f & 0x0008 != 0 {
+        hex_gillham |= 0x0200;
+    } // Bit  3 = B2
+    if f & 0x0004 != 0 {
+        hex_gillham |= 0x0002;
+    } // Bit  2 = D2
+    if f & 0x0002 != 0 {
+        hex_gillham |= 0x0400;
+    } // Bit  1 = B4
+    if f & 0x0001 != 0 {
+        hex_gillham |= 0x0004;
+    } // Bit  0 = D4
+
+    hex_gillham
+}
+
+fn parse_surveillance_identity(input: (&[u8], usize)) -> IResult<(&[u8], usize), ModeSMessageKind> {
+    let (_input, (_df, _flight_status, _downlink_req, _utility_msg, id_code, _parity)): (
+        _,
+        (u8, u8, u8, u8, u16, u32),
+    ) = tuple((
+        tag_bits(0b00101, 5u8),
+        take_bits(3u8),
+        take_bits(5u8),
+        take_bits(6u8),
+        take_bits(13u8),
+        take_bits(24u8),
+    ))(input)?;
+    let squawk_code = decode_id_13_field(id_code);
+    Ok((
+        input,
+        ModeSMessageKind::SurveillanceIdentity {
+            squawk: Squawk::from_u16(squawk_code),
+        },
+    ))
+}
+
+fn parse_mode_s_message_kind(input: (&[u8], usize)) -> IResult<(&[u8], usize), ModeSMessageKind> {
+    parse_surveillance_identity(input)
+}
+
+fn parse_mode_s_message(input: (&[u8], usize)) -> IResult<(&[u8], usize), MessageKind> {
+    let (input, kind) = parse_mode_s_message_kind(input)?;
+    let crc = mode_s_crc(input.0, 7).unwrap();
+    let icao = (
+        (crc & 0xFF0000) >> 16,
+        (crc & 0x00FF00) >> 8,
+        crc & 0x0000FF,
+    );
+    let message = MessageKind::ModeSMessage {
+        icao_address: ICAOAddress(icao.0 as u8, icao.1 as u8, icao.2 as u8),
+        kind,
+    };
+
+    Ok((input, message))
+}
+
 fn parse_message(input: &[u8]) -> IResult<&[u8], Message> {
     let (input, (downlink_format, kind, _)): (_, (u8, MessageKind, u32)) = bits(tuple((
         peek(take_bits(5u8)),
-        alt((parse_adsb_message, parse_unknown)),
+        alt((parse_mode_s_message, parse_adsb_message, parse_unknown)),
         // TODO: check CRC
         take_bits(24u32),
     )))(input)?;
@@ -240,8 +325,58 @@ pub fn parse_avr(data: &str) -> Result<(Message, &str), ParserError> {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     const CAPABILITY: u8 = 5;
+
+    #[test]
+    fn test_parse_mode_s_0() {
+        let r = b"\x28\x00\x1d\x8a\x2d\xa5\xae\x00\x00"; // AC3857 airborne squawking 5670.
+        let (_remaining, mm) = parse_mode_s_message_kind((r, 0)).expect("parse error");
+        assert_eq!(
+            mm,
+            ModeSMessageKind::SurveillanceIdentity {
+                squawk: Squawk::from_str("5670").unwrap()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_mode_s_1() {
+        let r = b"\x28\x00\x08\x08\xF4\x60\xE0\x00\x00\x00\x00"; // squawk 1200
+        let (_remaining, mm) = parse_mode_s_message((r, 0)).expect("parse error");
+        assert_eq!(
+            mm,
+            MessageKind::ModeSMessage {
+                icao_address: ICAOAddress(0xA4, 0x04, 0x42),
+                kind: ModeSMessageKind::SurveillanceIdentity {
+                    squawk: Squawk::from_str("1200").unwrap()
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_mode_s_2() {
+        // let r = b"00101 000 11111 101010 1111110101010 11111111 00000000 11111111";
+        // let r: [u8; 7] = [0b00101000, 0b11111101, 0b01011111, 0b10101010, 0b11111111, 0b00000000, 0b11111111];
+        // let r = b"\x20\x00\x15\xB8\xFC\x39\x7A\x00\x00";
+        // let r = b"\x20\x00\x04\x30\x19\x11\x27\x00\x00";
+        // let r = b"\x28\x00\x0C\x2C\xC1\x05\xD7\x00\x00";
+        // let r = b"\x20\x28\x04\x22\x34\x6C\xFF\x00\x00";
+        let r = b"\x28\x00\x08\x08\xF4\x60\xE0\x00\x00\x00\x00"; // squawk 1200
+        let (_remaining, mm) = parse_mode_s_message((r, 0)).expect("parse error");
+        assert_eq!(
+            mm,
+            MessageKind::ModeSMessage {
+                icao_address: ICAOAddress(0xA4, 0x04, 0x42),
+                kind: ModeSMessageKind::SurveillanceIdentity {
+                    squawk: Squawk::from_str("1200").unwrap()
+                }
+            }
+        );
+    }
 
     #[test]
     fn parse_aircraft_identification_message() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -359,12 +359,6 @@ mod tests {
 
     #[test]
     fn test_parse_mode_s_2() {
-        // let r = b"00101 000 11111 101010 1111110101010 11111111 00000000 11111111";
-        // let r: [u8; 7] = [0b00101000, 0b11111101, 0b01011111, 0b10101010, 0b11111111, 0b00000000, 0b11111111];
-        // let r = b"\x20\x00\x15\xB8\xFC\x39\x7A\x00\x00";
-        // let r = b"\x20\x00\x04\x30\x19\x11\x27\x00\x00";
-        // let r = b"\x28\x00\x0C\x2C\xC1\x05\xD7\x00\x00";
-        // let r = b"\x20\x28\x04\x22\x34\x6C\xFF\x00\x00";
         let r = b"\x28\x00\x08\x08\xF4\x60\xE0\x00\x00\x00\x00"; // squawk 1200
         let (_remaining, mm) = parse_mode_s_message((r, 0)).expect("parse error");
         assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_parse_mode_s_0() {
-        let r = b"\x28\x00\x1d\x8a\x2d\xa5\xae\x00\x00"; // AC3857 airborne squawking 5670.
+        let r = b"\x28\x00\x1d\x8a\x2d\xa5\xae"; // AC3857 airborne squawking 5670.
         let (_remaining, mm) = parse_mode_s_message_kind((r, 0)).expect("parse error");
         assert_eq!(
             mm,
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_parse_mode_s_1() {
-        let r = b"\x28\x00\x08\x08\xF4\x60\xE0\x00\x00\x00\x00"; // squawk 1200
+        let r = b"\x28\x00\x08\x08\xF4\x60\xE0"; // squawk 1200
         let (_remaining, mm) = parse_mode_s_message((r, 0)).expect("parse error");
         assert_eq!(
             mm,
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_parse_mode_s_2() {
-        let r = b"\x28\x00\x08\x08\xF4\x60\xE0\x00\x00\x00\x00"; // squawk 1200
+        let r = b"\x28\x00\x08\x08\xF4\x60\xE0"; // squawk 1200
         let (_remaining, mm) = parse_mode_s_message((r, 0)).expect("parse error");
         assert_eq!(
             mm,

--- a/src/types.rs
+++ b/src/types.rs
@@ -126,7 +126,6 @@ pub enum MessageKind {
 pub enum ModeSMessageKind {
     // DF=5
     SurveillanceIdentity { squawk: Squawk },
-    Unknown,
 }
 
 /// Kind of ADSB message.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use std::convert::From;
 use std::error::Error;
 use std::fmt;
+use std::str::FromStr;
 
 /// Error type used to convey parsing errors.
 #[derive(Debug)]
@@ -34,6 +35,30 @@ pub struct ICAOAddress(pub(crate) u8, pub(crate) u8, pub(crate) u8);
 impl fmt::Display for ICAOAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:02X}{:02X}{:02X}", self.0, self.1, self.2)
+    }
+}
+
+/// 16 bit transponder squawk code.
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub struct Squawk(pub(crate) u8, pub(crate) u8);
+
+impl Squawk {
+    pub fn from_u16(value: u16) -> Squawk {
+        Squawk(((value & 0xFF00) >> 8) as u8, (value & 0x00FF) as u8)
+    }
+}
+
+impl FromStr for Squawk {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Squawk::from_u16(u16::from_str_radix(value, 16)?))
+    }
+}
+
+impl fmt::Display for Squawk {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:02X}{:02X}", self.0, self.1)
     }
 }
 
@@ -71,7 +96,7 @@ pub enum VerticalRateSource {
 }
 
 /// ADS-B/Mode-S message.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Message {
     /// Downlink Format (DF)
     pub downlink_format: u8,
@@ -89,7 +114,18 @@ pub enum MessageKind {
         type_code: u8,
         kind: ADSBMessageKind,
     },
+    ModeSMessage {
+        icao_address: ICAOAddress,
+        kind: ModeSMessageKind,
+    },
     /// Unsupported message
+    Unknown,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ModeSMessageKind {
+    // DF=5
+    SurveillanceIdentity { squawk: Squawk },
     Unknown,
 }
 
@@ -122,4 +158,20 @@ pub enum ADSBMessageKind {
         /// Source for vertical rate information
         vertical_rate_source: VerticalRateSource,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_squawk() {
+        assert_eq!(Squawk::from_u16(22128), Squawk(86, 112));
+        assert_eq!(Squawk::from_str("5670").unwrap(), Squawk(86, 112));
+        assert_eq!(format!("{}", Squawk::from_str("5670").unwrap()), "5670");
+        // 4608 1200
+        assert_eq!(Squawk::from_u16(4608), Squawk(18, 0));
+        assert_eq!(Squawk::from_str("1200").unwrap(), Squawk(18, 0));
+        assert_eq!(format!("{}", Squawk::from_str("1200").unwrap()), "1200");
+    }
 }


### PR DESCRIPTION
I'm working on adding decoding of more message types. This one handles the Mode S "surveillance identity" response to get the transponder squawk code.

I'm a Rust beginner, and if possible I'd love your feedback on some things. I'm sure there are lots of small issues with my code, and I'd welcome any advice. A larger issue might be how I added `ModeSMessage` as another variant of `MessageKind`; does that seem right?  It feels a little odd to have nested `kind` fields.

Thanks for your time.
